### PR TITLE
added ability to inject ovs-kubernetes and crio config into kickstart

### DIFF
--- a/roles/image_builder/README.md
+++ b/roles/image_builder/README.md
@@ -118,6 +118,73 @@ microshift_image_firewall_options:
     port: 443/tcp
 ```
 
+### microshift_image_gateway_interface
+
+Type: string
+Required: false
+
+Ingress that is the API gateway 
+
+Example:
+```yaml
+microshift_image_gateway_interface: eth0
+```
+
+### microshift_image_external_gateway_interface
+
+Type: string
+Required: false
+
+Ingress routing external traffic to your services and pods inside the node
+
+Example:
+```yaml
+microshift_image_external_gateway_interface: eth1
+```
+
+### microshift_image_mtu
+
+Type: string
+Required: false
+
+MTU value used for the pods
+
+Example:
+```yaml
+microshift_image_mtu: 1400
+```
+
+### microshift_image_crio_proxy
+
+Type: complex
+Required: false
+
+Options for deploying a microshift cluster behind an http(s) proxy
+
+microshift_image_crio_proxy is a [YAML dictionary](https://docs.ansible.com/ansible/latest/reference_appendices/YAMLSyntax.html)
+type and has the following attributes:
+
+| Variable Name | Type                              | Required  | Default Value |
+|---------------|-----------------------------------|-----------|---------------|
+| user          | string                            | **Yes**   | n/a           |
+| password      | string                            | **Yes**   | n/a           |
+| server        | string                            | **Yes**   | n/a           |
+| port          | string                            | **Yes**   | n/a           |
+
+NOTES:
+
+Using this option will inject credentials into kickstart that is hosted via http
+
+Example:
+
+```yaml
+microshift_image_firewall_options:
+  - zone: trusted
+    source: 169.254.169.1
+  - zone: trusted
+    port: 443/tcp
+```
+
 Dependencies
 ------------
 

--- a/roles/image_builder/tasks/main.yml
+++ b/roles/image_builder/tasks/main.yml
@@ -7,6 +7,16 @@
     builder_custom_repos: "{{ microshift_image_custom_repos }}"
     builder_compose_pkgs: "{{ microshift_image_compose_pkgs }}"
 
+- name: check if ovn vars exist
+  when: microshift_image_gateway_interface is defined or microshift_image_external_gateway_interface is defined or microshift_image_mtu is defined
+  ansible.builtin.set_fact:
+    microshift_image_ovn_options_template: "{{ lookup('ansible.builtin.template', '../templates/ovn_options.j2') }}"
+
+- name: check if crio proxy is true
+  when: microshift_image_crio_proxy is defined
+  ansible.builtin.set_fact:
+    microshift_image_crio_proxy_template: "{{ lookup('ansible.builtin.template', '../templates/crio_proxy.j2') }}"
+
 - name: Running osbuild image builder
   ansible.builtin.import_role:
     name: infra.osbuild.builder
@@ -18,3 +28,5 @@
     builder_compose_customizations: "{{ microshift_image_compose_customizations }}"
     builder_kickstart_post: 
       - "{{ lookup('ansible.builtin.template', '../templates/firewall_options.j2') }}"
+      - "{{ microshift_image_ovn_options_template | default(omit) }}"
+      - "{{ microshift_image_crio_proxy_template | default(omit) }}"

--- a/roles/image_builder/templates/crio_proxy.j2
+++ b/roles/image_builder/templates/crio_proxy.j2
@@ -1,0 +1,6 @@
+mkdir /etc/systemd/system/crio.service.d/
+cat > /etc/systemd/system/crio.service.d/00-proxy.conf <<EOF
+Environment=NO_PROXY="localhost,127.0.0.
+Environment=HTTP_PROXY="http://{{ microshift_image_crio_proxy.user }}:{{ microshift_image_crio_proxy.password }}@{{ microshift_image_crio_proxy.server }}:{{ microshift_image_crio_proxy.port }}/"
+Environment=HTTPS_PROXY="http://{{ microshift_image_crio_proxy.user }}:{{ microshift_image_crio_proxy.password }}@{{ microshift_image_crio_proxy.server }}:{{ microshift_image_crio_proxy.port }}/"
+EOF

--- a/roles/image_builder/templates/ovn_options.j2
+++ b/roles/image_builder/templates/ovn_options.j2
@@ -1,0 +1,7 @@
+cat > /etc/microshift/ovn.yaml <<EOF
+ovsInit:
+  disableOVSInit: false
+  gatewayInterface: "{{ microshift_image_gateway_interface }}"
+  externalGatewayInterface: "{{ microshift_image_external_gateway_interface }}"
+mtu: {{ microshift_image_mtu }}
+EOF

--- a/roles/image_builder/vars/main.yml
+++ b/roles/image_builder/vars/main.yml
@@ -11,11 +11,3 @@ microshift_image_compose_customizations:
     password: "openshift"
     key: "{{ pubkey_file }}"
     groups: '["users", "wheel"]'
-# microshift_image_gateway_interface: "kk"
-# microshift_image_external_gateway_interface: "kjdk"
-# microshift_image_mtu: 1400
-# microshift_image_crio_proxy:
-#   user: user1
-#   password: pass1
-#   server: 192.183.3.333
-#   port: 123

--- a/roles/image_builder/vars/main.yml
+++ b/roles/image_builder/vars/main.yml
@@ -11,3 +11,11 @@ microshift_image_compose_customizations:
     password: "openshift"
     key: "{{ pubkey_file }}"
     groups: '["users", "wheel"]'
+# microshift_image_gateway_interface: "kk"
+# microshift_image_external_gateway_interface: "kjdk"
+# microshift_image_mtu: 1400
+# microshift_image_crio_proxy:
+#   user: user1
+#   password: pass1
+#   server: 192.183.3.333
+#   port: 123


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- Able to configure ovs-kubernetes
- Able to configure crio proxy 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
