### PR TITLE
Fix kickstart post omit issue

### DIFF
--- a/roles/image_builder/vars/main.yml
+++ b/roles/image_builder/vars/main.yml
@@ -15,8 +15,8 @@ microshift_image_compose_customizations:
 microshift_kickstart_post:
   - "{{ lookup('ansible.builtin.template', '../templates/firewall_options.j2') }}"
   - "{{ lookup('ansible.builtin.template', '../templates/lvms_setup.j2') }}"
-  - "{{ microshift_image_ovn_options_template | default(omit) }}"
-  - "{{ microshift_image_crio_proxy_template | default(omit) }}"
+  - "{{ microshift_image_ovn_options_template | default(None) }}"
+  - "{{ microshift_image_crio_proxy_template | default(None) }}"
 microshift_kickstart_options:
   - lang en_US.UTF-8
   - keyboard us


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Update microshift_kickstart_post variable to fix issue with omit in kickstart post described in [osbuild issue #96](https://github.com/redhat-cop/infra.osbuild/issues/96)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
