### PR TITLE
changed how kickstart post is used

### DIFF
--- a/roles/image_builder/tasks/main.yml
+++ b/roles/image_builder/tasks/main.yml
@@ -30,6 +30,6 @@
     builder_compose_type: "{{ microshift_image_compose_type }}"
     pubkey_file: "{{ microshift_image_pubkey }}"
     builder_compose_customizations: "{{ microshift_image_compose_customizations }}"
-    builder_kickstart_post: "{{ microshift_kickstart_post }}"
+    additional_kickstart_post: "{{ microshift_kickstart_post }}"
     builder_kickstart_options: "{{ microshift_kickstart_options }}"
     builder_rhsm_repos_info: "{{ microshift_rhsm_repos_info | default([]) }}"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- Uses the new updated way of adding kickstart post to osbuild by using the osbuild `additional_kickstart_post` var

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Consuming the update from https://github.com/redhat-cop/infra.osbuild/pull/132

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
