### PR TITLE
Revert "Remove general collection"

### DIFF
--- a/changelogs/fragments/40-remove-general-collection.yaml
+++ b/changelogs/fragments/40-remove-general-collection.yaml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - requirements - removed general collection and replaced it with redhat.rhel_system_roles collection.

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -45,7 +45,6 @@ tags: ['infrastructure']
 # range specifiers can be set and are separated by ','
 dependencies:
   "git+https://github.com/redhat-cop/infra.osbuild.git": "main"
-  "redhat.rhel_system_roles": ">1.0.0"
 
 # The URL of the originating SCM repository
 repository: https://github.com/ansible-collections/edge.microshift

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,5 +1,5 @@
 ---
 collections:
-  - redhat.rhel_system_roles
+  - community.general
   - ansible.posix
   - git+https://github.com/ansible-collections/edge.microshift.git


### PR DESCRIPTION
Reverts ansible-collections/edge.microshift#40
community.general is okay to use for now.